### PR TITLE
004 layer only

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ where `path` is the path to the source directory which you wish to package, and 
 `--output` (or `-o`) option specifies the zip file output.  If no `-o` option is given,
 the tool will display a preview of the file tree which it would package.
 
+If you have also specified a layer output (see "Configuration" below), you can choose
+to override any configuration files and prevent the main lambda package from being
+generated with the `--layer-only` option:
+
+```
+python -m lambda_package path --layer-only
+```
+
+This command effectively sets the lambda package output parameter, `output`, to `None`.
 
 ## Library usage
 
@@ -47,7 +56,7 @@ Note that the `exclude` option overrides any patterns in the `.gitignore` file.
 
 | Name             | Default | Description                                                                           |
 |------------------|---------|---------------------------------------------------------------------------------------|
-| `output`         | `None`  | The path of the zip file to be generated                                              |
+| `output`         | `None`  | The path of the lambda zip file to be generated.                                      |
 | `exclude`        | `None`  | A list of exclude pattern strings.  If not given, `.gitignore` is used instead.       |
 | `requirements`   | `None`  | The path to the requirements.txt file if Python dependencies are to be packaged.      |
 | `layer_output`   | `None`  | Path to a folder where requirement outputs should be stored rather than the package.  |

--- a/test/main_tests.py
+++ b/test/main_tests.py
@@ -1,0 +1,83 @@
+import unittest
+from unittest import mock
+from unittest.mock import Mock
+
+from lambda_package import Configuration
+from lambda_package.__main__ import get_configuration
+
+
+@mock.patch("lambda_package.Configuration.create_from_config_file")
+class LambdaPackageTests(unittest.TestCase):
+    """
+    General unit tests for the `__main__` module
+    """
+
+    def test_when_output_arg_given_then_overrides_configuration(
+        self, create_from_config_file_mock: Mock
+    ):
+
+        create_from_config_file_mock.return_value = Configuration(
+            output="my_output_config"
+        )
+
+        args = Mock()
+        args.output = "my_output_arg"
+        args.layer_only = False
+
+        validated_config = get_configuration(args)
+
+        self.assertEqual(validated_config.output, args.output)
+
+    def test_when_layer_only_given_then_output_is_none(
+        self, create_from_config_file_mock: Mock
+    ):
+
+        create_from_config_file_mock.return_value = Configuration(
+            output="my_output", layer_output="my_layer_output"
+        )
+
+        args = Mock()
+        args.output = None
+        args.layer_only = True
+
+        validated_config = get_configuration(args)
+
+        self.assertEqual(validated_config.output, None)
+
+    def test_when_layer_only_but_no_layer_output_then_error(
+        self, create_from_config_file_mock: Mock
+    ):
+
+        create_from_config_file_mock.return_value = Configuration(
+            output="my_output", layer_output=None,
+        )
+
+        args = Mock()
+        args.output = None
+        args.layer_only = True
+
+        self.assertRaisesRegex(
+            ValueError,
+            "A layer output must be specified when using --layer-only",
+            get_configuration,
+            args,
+        )
+
+    def test_when_layer_only_and_output_given_then_raises_error(
+        self, create_from_config_file_mock: Mock
+    ):
+
+        create_from_config_file_mock.return_value = Configuration(
+            output="my_output", layer_output="my_layout_output",
+        )
+
+        args = Mock()
+        args.output = "my_output"
+        args.layer_only = True
+
+        self.assertRaisesRegex(
+            ValueError,
+            "The --layer-only and --output parameters cannot be used together",
+            get_configuration,
+            args,
+        )


### PR DESCRIPTION
This PR adds the `--layer-only` CLI argument.  It actually works by clearing the `output` configuration parameter, so that the main package output is not generated.  If the argument is used without a `layer_output` config parameter, it will throw an error.  See the new unit tests for a full description of its behaviour.

Closes #4 